### PR TITLE
Fixes check for autoclose

### DIFF
--- a/mpas_analysis/shared/generalized_reader/generalized_reader.py
+++ b/mpas_analysis/shared/generalized_reader/generalized_reader.py
@@ -171,6 +171,9 @@ def open_multifile_dataset(fileNames, calendar, config,
     # select only the data in the specified range of dates
     ds = ds.sel(Time=slice(startDate, endDate))
 
+    # private record of autoclose use
+    ds.attrs['_autoclose'] = autoclose
+
     return ds  # }}}
 
 

--- a/mpas_analysis/test/test_generalized_reader.py
+++ b/mpas_analysis/test/test_generalized_reader.py
@@ -137,8 +137,14 @@ class TestGeneralizedReader(TestCase):
                 variableList=['mld'],
                 variableMap=variableMap)
 
+            # note, the asserts for autoclose below are only guaranteed 
+            # to work immediately following call to open_multifile_dataset
+            assert hasattr(ds, '_autoclose'), \
+                '`autoclose` not defined for dataset'
             if hasattr(ds, '_autoclose'):
-                assert(ds._autoclose == autoclose)
+                assert ds._autoclose == autoclose, \
+                        ('`autoclose` used for dataset is inconsistent '
+                         'with expected test value.')
 
             annualClimatologies.append(ds.mean(dim='Time'))
 


### PR DESCRIPTION
This PR fixes testing for autoclose in MPAS-Analysis https://github.com/MPAS-Dev/MPAS-Analysis/pull/151 to ensure that autoclose is used correctly for testing.